### PR TITLE
Fixed bug caused by a host with missing attributes. 

### DIFF
--- a/libnessus/objects/reporthost.py
+++ b/libnessus/objects/reporthost.py
@@ -9,7 +9,7 @@ from libnessus.objects.dictdiffer import DictDiffer
 from libnessus.objects import reportlogger
 from libnessus import exceptions as NessusExceptions
 
-log = reportlogger.ReportLogger
+log = reportlogger.ReportLogger('HOST PARSER')
 
 class NessusReportHost(object):
     """
@@ -23,8 +23,7 @@ class NessusReportHost(object):
         if len(_missing_attr) == 0:
             self.__host_properties = host_properties
         else:
-            log.debug("Host Missing Attributes: ")
-            log.debug(host_properties)
+            log.debug('Missing Attributes: ' + ' '.join(host_properties))
             raise NessusExceptions.MissingAttribute("Not all the attributes to create a decent "
                             "NessusReportHost are available. "
                             "Missing: {}".format(" ".join(_missing_attr)))

--- a/libnessus/parser.py
+++ b/libnessus/parser.py
@@ -62,9 +62,14 @@ class NessusParser(object):
         for nessus_report in root.findall("Report"):
             nessus_hosts = []
             for nessus_host in nessus_report.findall("ReportHost"):
-                _nhost = cls.parse_host(nessus_host, strict)
-                nessus_hosts.append(_nhost)
-
+                try:
+                    _nhost = cls.parse_host(nessus_host, strict)
+                    nessus_hosts.append(_nhost)
+                except:
+                    NessusExceptions.MissingAttribute:
+                        if strict:
+                            raise
+                        continue
             if 'name' in nessus_report.attrib:
                 report_name = nessus_report.attrib['name']
             else:
@@ -73,6 +78,15 @@ class NessusParser(object):
             nrp = NessusReport(name=report_name, hosts=nessus_hosts)
 
         return nrp
+
+try:
+    _nhost = cls.parse_host(nessus_host, strict)
+    nessus_hosts.append(_nhost)
+except NessusExceptions.MissingAttribute:
+    if strict:
+        raise
+    else continue
+
 
     @classmethod
     def parse_host(cls, root=None, strict=False):

--- a/libnessus/parser.py
+++ b/libnessus/parser.py
@@ -65,11 +65,10 @@ class NessusParser(object):
                 try:
                     _nhost = cls.parse_host(nessus_host, strict)
                     nessus_hosts.append(_nhost)
-                except:
-                    NessusExceptions.MissingAttribute:
-                        if strict:
-                            raise
-                        continue
+                except NessusExceptions.MissingAttribute:
+                    if strict:
+                        raise
+                    continue
             if 'name' in nessus_report.attrib:
                 report_name = nessus_report.attrib['name']
             else:
@@ -78,14 +77,6 @@ class NessusParser(object):
             nrp = NessusReport(name=report_name, hosts=nessus_hosts)
 
         return nrp
-
-try:
-    _nhost = cls.parse_host(nessus_host, strict)
-    nessus_hosts.append(_nhost)
-except NessusExceptions.MissingAttribute:
-    if strict:
-        raise
-    else continue
 
 
     @classmethod


### PR DESCRIPTION
In certain cases, Nessus scans which contain hosts with no information other than Nessus Configuration settings. These settings appear as "Info" vulnerability objects with no attributes, which results in a MissingAttribute exception. Ordinarily, this is handled by `cls.parsehost()`, but in cases where a host does not contain any vulnerabilities which supply all necessary attributes, the exception is raised regardless. Annoyingly, this caused the parser to break. :neutral_face: 

I added an try/except clause to handle this issue when host findings are missing required attributes and throw out the result unless strict parsing is enabled. This is not ideal, but it would be better to accept all known good hosts and throw out any anomalies rather than forcing the parser to bail out unless that is what the user wants (ie: via strict parsing).

This is a _temporary_ fix until we can add better handling of these rogue Nessus configuration setting objects. Ultimately, the solution may be to remove this exception altogether and simply allow a greedy ingestion of all of these nessus objects, and to no longer require certain attributes. :confused: 

P.S. Also fixed one of my earliest mistakes when implementing the report logger. Forgot to issue it a name, which created a copy of the class instead of an instance of it. Whoops. :sweat_smile: 